### PR TITLE
Tweaking hipster glasses mapping and auth header

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
-if (!process.env.MASHAPE_API_KEY || !process.env.MASHAPE_API_SECRET) {
-  throw new Error("Need to set MASHAPE_API_KEY and MASHAPE_API_SECRET")
+if (!process.env.MASHAPE_API_KEY) {
+  throw new Error("Need to set MASHAPE_API_KEY")
 }
 
 /**

--- a/lib/image.js
+++ b/lib/image.js
@@ -17,7 +17,7 @@ var mashapeHash = crypto.createHmac('sha1', process.env.MASHAPE_API_SECRET)
     .update(process.env.MASHAPE_API_KEY)
     .digest('hex')
 
-var mashapeAuth = Buffer(process.env.MASHAPE_API_KEY + ':' + mashapeHash).toString('base64')
+var mashapeAuth = Buffer(process.env.MASHAPE_API_KEY).toString()
 
 var queue = []
   , inUse = false

--- a/mapping.coffee
+++ b/mapping.coffee
@@ -8,8 +8,8 @@
 
 module.exports =
   hipster: affine (face) -> [
-    [138, 80, face.eye_left]
-    [314, 80, face.eye_right]
+    [314, 80, face.eye_left]
+    [138, 80, face.eye_right]
   ]
 
   disguise: affine (face) -> [


### PR DESCRIPTION
I had to slightly tweak how the X-Mashape-Authorization header is sent. I'm new to mashape so this may be a mistake, but I could only find docs with the API key and no secret. Still works with my production key on localhost.
